### PR TITLE
Adapt gpi-space instructions for 21.03

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -14,7 +14,7 @@ include (add_macros)
 include (beautify_find_boost)
 include (beautify_find_GPISpace)
 
-find_package (GPISpace REQUIRED COMPONENTS VERSION=20.12)
+find_package (GPISpace REQUIRED COMPONENTS)
 find_boost (1.61 REQUIRED QUIET FROM_GPISPACE_INSTALLATION COMPONENTS
   date_time
   filesystem


### PR DESCRIPTION
Some significant changes were made in the CMakelists of GPI-Space.  This commit brings both the project and the REAME.md instructions in line with that. 